### PR TITLE
Add initiallyHidden columnlist option

### DIFF
--- a/Model/Config/GridXmlToArrayConverter.php
+++ b/Model/Config/GridXmlToArrayConverter.php
@@ -234,6 +234,7 @@ class GridXmlToArrayConverter
             $this->getAttributeConfig($columnElement, 'sortable'),
             $this->getAttributeConfig($columnElement, 'source'),
             $this->getAttributeConfig($columnElement, 'template'),
+            $this->getAttributeConfig($columnElement, 'isInitiallyHidden'),
             $this->getColumnOptionsConfig($columnElement),
         ));
     }

--- a/Model/Config/GridXmlToArrayConverter.php
+++ b/Model/Config/GridXmlToArrayConverter.php
@@ -234,7 +234,7 @@ class GridXmlToArrayConverter
             $this->getAttributeConfig($columnElement, 'sortable'),
             $this->getAttributeConfig($columnElement, 'source'),
             $this->getAttributeConfig($columnElement, 'template'),
-            $this->getAttributeConfig($columnElement, 'isInitiallyHidden'),
+            $this->getAttributeConfig($columnElement, 'initiallyHidden'),
             $this->getColumnOptionsConfig($columnElement),
         ));
     }

--- a/Test/Unit/Model/Config/GridXmlToArrayConverterTest.php
+++ b/Test/Unit/Model/Config/GridXmlToArrayConverterTest.php
@@ -193,7 +193,7 @@ EOXML;
             <column name="id" sortOrder="1"/>
             <column name="note" type="text" template="Module_Name::file.phtml"/>
             <column name="name" rendererBlockName="name-renderer-block"/>
-            <column name="speed" label="km/h"/>
+            <column name="speed" label="km/h" isInitiallyHidden="true"/>
             <column name="logo" renderAsUnsecureHtml="true" sortable="false"/>
             <column name="color" source="My\SourceModel"/>
             <column name="background_color">
@@ -224,7 +224,7 @@ EOXML;
                     ['key' => 'id', 'sortOrder' => '1'],
                     ['key' => 'note', 'type' => 'text', 'template' => 'Module_Name::file.phtml'],
                     ['key' => 'name', 'rendererBlockName' => 'name-renderer-block'],
-                    ['key' => 'speed', 'label' => 'km/h'],
+                    ['key' => 'speed', 'label' => 'km/h', 'isInitiallyHidden' => 'true'],
                     ['key' => 'logo', 'renderAsUnsecureHtml' => 'true', 'sortable' => 'false'],
                     ['key' => 'color', 'source' => 'My\SourceModel'],
                     ['key' => 'background_color', 'options' => $options],

--- a/Test/Unit/Model/Config/GridXmlToArrayConverterTest.php
+++ b/Test/Unit/Model/Config/GridXmlToArrayConverterTest.php
@@ -193,7 +193,7 @@ EOXML;
             <column name="id" sortOrder="1"/>
             <column name="note" type="text" template="Module_Name::file.phtml"/>
             <column name="name" rendererBlockName="name-renderer-block"/>
-            <column name="speed" label="km/h" isInitiallyHidden="true"/>
+            <column name="speed" label="km/h" initiallyHidden="true"/>
             <column name="logo" renderAsUnsecureHtml="true" sortable="false"/>
             <column name="color" source="My\SourceModel"/>
             <column name="background_color">
@@ -224,7 +224,7 @@ EOXML;
                     ['key' => 'id', 'sortOrder' => '1'],
                     ['key' => 'note', 'type' => 'text', 'template' => 'Module_Name::file.phtml'],
                     ['key' => 'name', 'rendererBlockName' => 'name-renderer-block'],
-                    ['key' => 'speed', 'label' => 'km/h', 'isInitiallyHidden' => 'true'],
+                    ['key' => 'speed', 'label' => 'km/h', 'initiallyHidden' => 'true'],
                     ['key' => 'logo', 'renderAsUnsecureHtml' => 'true', 'sortable' => 'false'],
                     ['key' => 'color', 'source' => 'My\SourceModel'],
                     ['key' => 'background_color', 'options' => $options],

--- a/Test/Unit/ViewModel/HyvaGrid/ColumnDefinitionTest.php
+++ b/Test/Unit/ViewModel/HyvaGrid/ColumnDefinitionTest.php
@@ -50,7 +50,7 @@ class ColumnDefinitionTest extends TestCase
                 ['value' => 'bbb', 'label' => 'Bbb'],
             ],
             'isVisible'            => true,
-            'isInitiallyHidden'    => 'true'
+            'initiallyHidden'      => 'true'
         ];
 
         $column1 = new ColumnDefinition($dummyObjectManager, ...values($original));

--- a/Test/Unit/ViewModel/HyvaGrid/ColumnDefinitionTest.php
+++ b/Test/Unit/ViewModel/HyvaGrid/ColumnDefinitionTest.php
@@ -50,6 +50,7 @@ class ColumnDefinitionTest extends TestCase
                 ['value' => 'bbb', 'label' => 'Bbb'],
             ],
             'isVisible'            => true,
+            'isInitiallyHidden'    => 'true'
         ];
 
         $column1 = new ColumnDefinition($dummyObjectManager, ...values($original));

--- a/ViewModel/HyvaGrid/ColumnDefinition.php
+++ b/ViewModel/HyvaGrid/ColumnDefinition.php
@@ -31,6 +31,8 @@ class ColumnDefinition implements ColumnDefinitionInterface
 
     private ?string $sortable;
 
+    private ?string $isInitiallyHidden;
+
     public function __construct(
         ObjectManagerInterface $objectManager,
         string $key,
@@ -43,7 +45,8 @@ class ColumnDefinition implements ColumnDefinitionInterface
         ?string $sortable = null,
         ?string $source = null,
         ?array $options = null,
-        ?bool $isVisible = null
+        ?bool $isVisible = null,
+        ?string $isInitiallyHidden = null
     ) {
         $this->objectManager        = $objectManager;
         $this->key                  = $key;
@@ -57,6 +60,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
         $this->source               = $source;
         $this->options              = $options;
         $this->isVisible            = $isVisible;
+        $this->isInitiallyHidden    = $isInitiallyHidden;
     }
 
     private function camelCaseToWords(string $camel): string
@@ -105,6 +109,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
             'source'               => $this->source,
             'options'              => $this->options,
             'isVisible'            => $this->isVisible,
+            'isInitiallyHidden'    => $this->isInitiallyHidden
         ];
     }
 
@@ -151,5 +156,10 @@ class ColumnDefinition implements ColumnDefinitionInterface
     public function isSortable(): bool
     {
         return !isset($this->sortable) || $this->sortable !== 'false';
+    }
+
+    public function getIsInitiallyHidden(): bool
+    {
+        return isset($this->isInitiallyHidden) && $this->isInitiallyHidden === 'true';
     }
 }

--- a/ViewModel/HyvaGrid/ColumnDefinition.php
+++ b/ViewModel/HyvaGrid/ColumnDefinition.php
@@ -31,7 +31,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
 
     private ?string $sortable;
 
-    private ?string $isInitiallyHidden;
+    private ?string $initiallyHidden;
 
     public function __construct(
         ObjectManagerInterface $objectManager,
@@ -46,7 +46,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
         ?string $source = null,
         ?array $options = null,
         ?bool $isVisible = null,
-        ?string $isInitiallyHidden = null
+        ?string $initiallyHidden = null
     ) {
         $this->objectManager        = $objectManager;
         $this->key                  = $key;
@@ -60,7 +60,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
         $this->source               = $source;
         $this->options              = $options;
         $this->isVisible            = $isVisible;
-        $this->isInitiallyHidden    = $isInitiallyHidden;
+        $this->initiallyHidden      = $initiallyHidden;
     }
 
     private function camelCaseToWords(string $camel): string
@@ -109,7 +109,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
             'source'               => $this->source,
             'options'              => $this->options,
             'isVisible'            => $this->isVisible,
-            'isInitiallyHidden'    => $this->isInitiallyHidden
+            'initiallyHidden'      => $this->initiallyHidden
         ];
     }
 
@@ -160,6 +160,6 @@ class ColumnDefinition implements ColumnDefinitionInterface
 
     public function isInitiallyHidden(): bool
     {
-        return isset($this->isInitiallyHidden) && $this->isInitiallyHidden === 'true';
+        return isset($this->initiallyHidden) && $this->initiallyHidden === 'true';
     }
 }

--- a/ViewModel/HyvaGrid/ColumnDefinition.php
+++ b/ViewModel/HyvaGrid/ColumnDefinition.php
@@ -158,7 +158,7 @@ class ColumnDefinition implements ColumnDefinitionInterface
         return !isset($this->sortable) || $this->sortable !== 'false';
     }
 
-    public function getIsInitiallyHidden(): bool
+    public function isInitiallyHidden(): bool
     {
         return isset($this->isInitiallyHidden) && $this->isInitiallyHidden === 'true';
     }

--- a/ViewModel/HyvaGrid/ColumnDefinitionInterface.php
+++ b/ViewModel/HyvaGrid/ColumnDefinitionInterface.php
@@ -24,5 +24,5 @@ interface ColumnDefinitionInterface
 
     public function isVisible(): bool;
 
-    public function getIsInitiallyHidden(): bool;
+    public function isInitiallyHidden(): bool;
 }

--- a/ViewModel/HyvaGrid/ColumnDefinitionInterface.php
+++ b/ViewModel/HyvaGrid/ColumnDefinitionInterface.php
@@ -23,4 +23,6 @@ interface ColumnDefinitionInterface
     public function isSortable(): bool;
 
     public function isVisible(): bool;
+
+    public function getIsInitiallyHidden(): bool;
 }

--- a/doc/1. Overview/2. Quickstart/Examples/4. Repository::getList Grid Data Provider.md
+++ b/doc/1. Overview/2. Quickstart/Examples/4. Repository::getList Grid Data Provider.md
@@ -25,6 +25,7 @@ The configuration can be as simple as the previous minimalist array provider exa
                     template="Hyva_AdminTest::image.phtml"/>
             <column name="media_gallery" renderAsUnsecureHtml="true"/>
             <column name="price" type="price"/>
+            <column name="short_description" isInitiallyHidden="true"/>
         </include>
         <exclude>
             <column name="category_gear"/>

--- a/doc/1. Overview/2. Quickstart/Examples/4. Repository::getList Grid Data Provider.md
+++ b/doc/1. Overview/2. Quickstart/Examples/4. Repository::getList Grid Data Provider.md
@@ -25,7 +25,7 @@ The configuration can be as simple as the previous minimalist array provider exa
                     template="Hyva_AdminTest::image.phtml"/>
             <column name="media_gallery" renderAsUnsecureHtml="true"/>
             <column name="price" type="price"/>
-            <column name="short_description" isInitiallyHidden="true"/>
+            <column name="short_description" initiallyHidden="true"/>
         </include>
         <exclude>
             <column name="category_gear"/>

--- a/doc/1. Overview/3. Walkthrough/5. Configuring Columns.md
+++ b/doc/1. Overview/3. Walkthrough/5. Configuring Columns.md
@@ -47,8 +47,7 @@ They are (in alphabetical order):
 
 
 * label
-
-
+* isInitiallyHidden  
 * name
 * renderAsUnsecureHtml
 * rendererBlockName
@@ -60,5 +59,3 @@ They are (in alphabetical order):
 
 
 For more information on the attributes, I suggest you inspect the auto-completion offered by your editor, or have a look at the Grid XML API reference (or read the schema XSD file).
-
-

--- a/doc/1. Overview/3. Walkthrough/5. Configuring Columns.md
+++ b/doc/1. Overview/3. Walkthrough/5. Configuring Columns.md
@@ -47,7 +47,7 @@ They are (in alphabetical order):
 
 
 * label
-* isInitiallyHidden  
+* initiallyHidden
 * name
 * renderAsUnsecureHtml
 * rendererBlockName

--- a/doc/2. API Reference/Grid XML Reference/grid > columns/grid > columns > include/grid > columns > include > column.md
+++ b/doc/2. API Reference/Grid XML Reference/grid > columns/grid > columns > include/grid > columns > include > column.md
@@ -14,6 +14,7 @@ The include `column` can have a number of attributes, almost all of which are op
 * sortOrder
 * sortable
 * source
+* isInitiallyHidden
 
 
 In the following you can find a description of each column attribute.
@@ -184,3 +185,16 @@ The class has to implement the `\Magento\Eav\Model\Entity\Attribute\Source\Sourc
 
 
 Note that for simple cases attribute options can also be configured using option child elements. Please refer to the grid:columns:include:column:option documentation for more information.
+
+
+### isInitiallyHidden
+
+By default, all columns inside the <include> section will be displayed on the grid the first time it is loaded.
+
+If you need to hide that column by default, but keep at the same time the option to display it on the grid, you can set this option to "true".
+
+Note that this only affects to the initial state of the grid. Once it has been loaded for the first time, a session variable will be set storing the column states.
+
+```markup
+<column name="image" isInitiallyHidden="true"/>
+```

--- a/doc/2. API Reference/Grid XML Reference/grid > columns/grid > columns > include/grid > columns > include > column.md
+++ b/doc/2. API Reference/Grid XML Reference/grid > columns/grid > columns > include/grid > columns > include > column.md
@@ -14,7 +14,7 @@ The include `column` can have a number of attributes, almost all of which are op
 * sortOrder
 * sortable
 * source
-* isInitiallyHidden
+* initiallyHidden
 
 
 In the following you can find a description of each column attribute.
@@ -187,7 +187,7 @@ The class has to implement the `\Magento\Eav\Model\Entity\Attribute\Source\Sourc
 Note that for simple cases attribute options can also be configured using option child elements. Please refer to the grid:columns:include:column:option documentation for more information.
 
 
-### isInitiallyHidden
+### initiallyHidden
 
 By default, all columns inside the <include> section will be displayed on the grid the first time it is loaded.
 
@@ -196,5 +196,5 @@ If you need to hide that column by default, but keep at the same time the option
 Note that this only affects to the initial state of the grid. Once it has been loaded for the first time, a session variable will be set storing the column states.
 
 ```markup
-<column name="image" isInitiallyHidden="true"/>
+<column name="image" initiallyHidden="true"/>
 ```

--- a/etc/hyva-grid.xsd
+++ b/etc/hyva-grid.xsd
@@ -127,6 +127,7 @@
         <xs:attribute name="sortable" type="boolean"/>
         <xs:attribute name="renderAsUnsecureHtml" type="boolean"/>
         <xs:attribute name="source" type="phpType"/>
+        <xs:attribute name="isInitiallyHidden" type="boolean"/>
     </xs:complexType>
 
     <xs:complexType name="baseActionType">

--- a/etc/hyva-grid.xsd
+++ b/etc/hyva-grid.xsd
@@ -127,7 +127,7 @@
         <xs:attribute name="sortable" type="boolean"/>
         <xs:attribute name="renderAsUnsecureHtml" type="boolean"/>
         <xs:attribute name="source" type="phpType"/>
-        <xs:attribute name="isInitiallyHidden" type="boolean"/>
+        <xs:attribute name="initiallyHidden" type="boolean"/>
     </xs:complexType>
 
     <xs:complexType name="baseActionType">

--- a/view/adminhtml/templates/grid.phtml
+++ b/view/adminhtml/templates/grid.phtml
@@ -413,7 +413,6 @@ $uniqueId = '_' . uniqid();
 
                 initState() {
                     this.$watch('selectedRows', this.storeSelectedRows.bind(this));
-                    this.$watch('hiddenCols', this.storeHiddenColumns.bind(this));
                     this.selectedRows = this.getSelectedRows();
                     this.hiddenCols = this.getHiddenCols();
                 },
@@ -435,6 +434,7 @@ $uniqueId = '_' . uniqid();
                     } else {
                         this.hiddenCols.push(key);
                     }
+                    this.storeHiddenColumns();
                 },
 
                 isColumnVisible(key) {

--- a/view/adminhtml/templates/grid.phtml
+++ b/view/adminhtml/templates/grid.phtml
@@ -390,7 +390,13 @@ $uniqueId = '_' . uniqid();
             return {
                 refs: false,
                 selectedRows: [],
-                hiddenCols: [],
+                hiddenCols: [
+                    <?php foreach ($grid->getColumnDefinitions() as $column): ?>
+                        <?php if ($column->getIsInitiallyHidden()): ?>
+                        'col-<?= $escaper->escapeHtml($column->getKey()) ?>',
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                ],
                 massActionStorageName: '<?= $escaper->escapeHtml($grid->getGridName()) . '-selectedRows' ?>',
                 hiddenColsStorageName: '<?= $escaper->escapeHtml($grid->getGridName()) . '-hiddenCols' ?>',
 
@@ -419,7 +425,7 @@ $uniqueId = '_' . uniqid();
 
                 getHiddenCols() {
                     const hiddenColsJson = window.sessionStorage.getItem(this.hiddenColsStorageName);
-                    return hiddenColsJson ? JSON.parse(hiddenColsJson) : [];
+                    return hiddenColsJson ? JSON.parse(hiddenColsJson) : JSON.parse(JSON.stringify(this.hiddenCols));
                 },
 
                 toggleColumn(key) {

--- a/view/adminhtml/templates/grid.phtml
+++ b/view/adminhtml/templates/grid.phtml
@@ -392,7 +392,7 @@ $uniqueId = '_' . uniqid();
                 selectedRows: [],
                 hiddenCols: [
                     <?php foreach ($grid->getColumnDefinitions() as $column): ?>
-                        <?php if ($column->getIsInitiallyHidden()): ?>
+                        <?php if ($column->isInitiallyHidden()): ?>
                         'col-<?= $escaper->escapeHtml($column->getKey()) ?>',
                         <?php endif; ?>
                     <?php endforeach; ?>
@@ -425,7 +425,7 @@ $uniqueId = '_' . uniqid();
 
                 getHiddenCols() {
                     const hiddenColsJson = window.sessionStorage.getItem(this.hiddenColsStorageName);
-                    return hiddenColsJson ? JSON.parse(hiddenColsJson) : JSON.parse(JSON.stringify(this.hiddenCols));
+                    return hiddenColsJson ? JSON.parse(hiddenColsJson) : this.hiddenCols;
                 },
 
                 toggleColumn(key) {


### PR DESCRIPTION
Hi @Vinai,

I've added the new column option. As you described

- I first modified the Unit Tests and check that they failed. There was only one test more to modify to get them OK: Test/Unit/ViewModel/HyvaGrid/ColumnDefinitionTest.php
- Option name is: isInitiallyHidden
- The grid.phtml modifications work fine. As I'm not a js specialist, I'm not sure this is the best way to do it. 
- I've updated the docs to include the information about this new column

If you have any recommendations, comments, modifications to perform... please let me know.

