### PR TITLE
Added decimal data type

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -72,6 +72,7 @@
                 <item name="int" xsi:type="string">Hyva\Admin\Model\DataType\IntDataType</item>
                 <item name="scalar_null" xsi:type="string">Hyva\Admin\Model\DataType\ScalarAndNullDataType</item>
                 <item name="price" xsi:type="string">Hyva\Admin\Model\DataType\PriceDataType</item>
+                <item name="decimal" xsi:type="string">Hyva\Admin\Model\DataType\ScalarAndNullDataType</item>
                 <item name="magento_product" xsi:type="string">Hyva\Admin\Model\DataType\ProductDataType</item>
                 <item name="magento_category_link" xsi:type="string">Hyva\Admin\Model\DataType\CategoryLinkDataType</item>
                 <item name="magento_stock_item" xsi:type="string">Hyva\Admin\Model\DataType\StockItemDataType</item>


### PR DESCRIPTION
Found this problem in "Total Qty" column while implementing [Sales > Shipments grid](https://github.com/redmonks/magento2-module-hyva-admin-sales-grids).

The change has been suggested by @Vinai over slack conversion.

![miissing-decimal-data-type](https://user-images.githubusercontent.com/5336201/120587120-62ddd680-c452-11eb-9796-e4f17483534c.jpeg)
