### PR TITLE
Format addressDataType if no firstname or lastname set

### DIFF
--- a/Model/DataType/CustomerAddressDataType.php
+++ b/Model/DataType/CustomerAddressDataType.php
@@ -7,6 +7,7 @@ use Magento\Customer\Api\Data\AddressInterface;
 
 use Magento\Customer\Model\Address\AddressModelInterface;
 use function array_filter as filter;
+use function array_map as map;
 
 class CustomerAddressDataType implements DataTypeInterface
 {
@@ -66,6 +67,6 @@ class CustomerAddressDataType implements DataTypeInterface
             $value->getPostcode(),
             $value->getCountryId(),
         ];
-        return implode(', ', filter($parts));
+        return implode(', ', filter(map('trim', $parts)));
     }
 }


### PR DESCRIPTION
Format CustomerAddressDataType.php to remove space and comma if no firstname or lastname are set.

Before
![Screenshot from 2021-07-01 16-33-26](https://user-images.githubusercontent.com/40339403/124151317-54eb9780-da8a-11eb-916b-480caffcc363.png)

After
![Screenshot from 2021-07-01 16-32-45](https://user-images.githubusercontent.com/40339403/124151308-52893d80-da8a-11eb-9d89-e51445cf36a4.png)



