### PR TITLE
Fixed grid processors xsd definition

### DIFF
--- a/etc/hyva-grid.xsd
+++ b/etc/hyva-grid.xsd
@@ -441,7 +441,7 @@
 
     <xs:complexType name="gridProcessorsType">
         <xs:sequence>
-            <xs:element name="processor" minOccurs="0" maxOccurs="1">
+            <xs:element name="processor" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:attribute name="class" type="phpType"/>
                     <xs:attribute name="enabled" type="boolean"/>


### PR DESCRIPTION
When using multiple grid processors Magento throws error due to XSD validation failure.

Reproduction: add more than one grid processor
```
<source>
    <processors>
        <processor class="Hyva\AdminTest\HyvaGridProcessor\ProductGridQueryProcessor"/>
        <processor class="Hyva\AdminTest\HyvaGridProcessor\ProductGridQueryProcessor2"/>
    </processors>
</source>
```

```
1 exception(s):
Exception #0 (Magento\Framework\Config\Dom\ValidationException): Element 'processor': This element is not expected.
```
