### PR TITLE
fix: repo item type fqdn if namespace equals

### DIFF
--- a/Model/GridSourceType/RepositorySourceType/RepositorySourceFactory.php
+++ b/Model/GridSourceType/RepositorySourceType/RepositorySourceFactory.php
@@ -51,7 +51,6 @@ class RepositorySourceFactory
         $class  = $this->getSourceRepoClass($sourceConfig);
         $method = $this->getSourceRepoMethod($sourceConfig);
         $resultType      = $this->reflectionMethodsMap->getMethodReturnType($class, $method);
-        $resultItemsType = $this->reflectionMethodsMap->getMethodReturnType($resultType, 'getItems');
         
         $resultItemsType = $this->reflectionMethodsMap->getMethodReturnType($resultType, 'getItems');
         if (strpos($resultItemsType, "\\") === false) {

--- a/Model/GridSourceType/RepositorySourceType/RepositorySourceFactory.php
+++ b/Model/GridSourceType/RepositorySourceType/RepositorySourceFactory.php
@@ -52,6 +52,14 @@ class RepositorySourceFactory
         $method = $this->getSourceRepoMethod($sourceConfig);
         $resultType      = $this->reflectionMethodsMap->getMethodReturnType($class, $method);
         $resultItemsType = $this->reflectionMethodsMap->getMethodReturnType($resultType, 'getItems');
+        
+        $resultItemsType = $this->reflectionMethodsMap->getMethodReturnType($resultType, 'getItems');
+        if (strpos($resultItemsType, "\\") === false) {
+            $typeData = explode("\\", $resultType);
+            unset($typeData[count($typeData) - 1]);
+
+            $resultItemsType = join("\\", $typeData) . "\\$resultItemsType";
+        }
 
         return substr($resultItemsType, -2) === '[]'
             ? substr($resultItemsType, 0, -2)


### PR DESCRIPTION
Once `SearchResultsInterface` and `ItemInterface` share the same namespace, reflection returns $resultItemsType relative to $resultType, while the module requires FQDN

Current behavior:
```
$resultType = Vendor\Module\Api\Data\SearchResultsInterface
$resultItemsType = ItemInterface[]
```

Fixed behavior:
```
$resultType = Vendor\Module\Api\Data\SearchResultsInterface
$resultItemsType = Vendor\Module\Api\Data\ItemInterface[]
```