### PR TITLE
Validate return type using reflection

### DIFF
--- a/Model/GridSourceType/RepositorySourceType/RepositorySourceFactory.php
+++ b/Model/GridSourceType/RepositorySourceType/RepositorySourceFactory.php
@@ -129,7 +129,16 @@ class RepositorySourceFactory
         $class  = $this->getSourceRepoClass($sourceConfig);
         $method = $this->getSourceRepoMethod($sourceConfig);
 
-        $returnType      = $this->reflectionMethodsMap->getMethodReturnType($class, $method);
+        try {
+            $returnNamedType = (new \ReflectionClass($class))->getMethod($method)->getReturnType();
+
+            if ($returnNamedType instanceof \ReflectionNamedType) {
+                $returnType = $returnNamedType->getName();
+            }
+        } catch (\ReflectionException) {
+        }
+
+        $returnType    ??= $this->reflectionMethodsMap->getMethodReturnType($class, $method);
         $resultInterface = SearchResultsInterface::class;
         if (!is_subclass_of($returnType, $resultInterface)) {
             $msg = sprintf('The repository source "%s" does not return a %s instance', $sourceConfig, $resultInterface);


### PR DESCRIPTION
This change aims to use declared method return type value, if defined, over doc block `@return` tag annotation, for `\Hyva\Admin\Model\GridSourceType\RepositorySourceType\RepositorySourceFactory::validateReturnType` validation.

It has been tested against the following PHP versions:
[7.3](https://php-play.dev/?c=DwfgDgFmBQB2CGBbApgZzPAxsgBAFTQBcBLWAcwG5ppTDkAnAMy1wCU0BXAG0IElY6TFjgDeAX2qYu8VKhwARZIgD20EdByacYDgCMuxTDkYdYmEstg46qQgAoAlAC4c7VNz4CGzbKIkToABIpGTkAXhwAcgAdAltSMmjFFUiqQJRCCGUAExwIyJtCVOpCegBPUWgASED6ZEYuZHNiSwBhaVk8nFhkAHccaPYGpotYdtC7YI7UByotHFrkQg56WAA5JGRsvDKwXAjF4ea26YBaAD4yJYBZJazsyYz7hwurwnZl1Z29xyoNLWIjBwkzqn3Wm22u1wpFs8DMyGUQMG9Uax3BKEhewclXm80WYO%2B%2BwWoJW6K2hNeSw2KF%2B-00-hwmHghEwEGByKOowAogAPbBgUYLZDY9QBJpZYlLUmEnAgEBRUwAa1gyl6sFSQA&v=7.3&f=console) - [7.4](https://php-play.dev/?c=DwfgDgFmBQB2CGBbApgZzPAxsgBAFTQBcBLWAcwG5ppTDkAnAMy1wCU0BXAG0IElY6TFjgDeAX2qYu8VKhwARZIgD20EdByacYDgCMuxTDkYdYmEstg46qQgAoAlAC4c7VNz4CGzbKIkToABIpGTkAXhwAcgAdAltSMmjFFUiqQJRCCGUAExwIyJtCVOpCegBPUWgASED6ZEYuZHNiSwBhaVk8nFhkAHccaPYGpotYdtC7YI7UByotHFrkQg56WAA5JGRsvDKwXAjF4ea26YBaAD4yJYBZJazsyYz7hwurwnZl1Z29xyoNLWIjBwkzqn3Wm22u1wpFs8DMyGUQMG9Uax3BKEhewclXm80WYO%2B%2BwWoJW6K2hNeSw2KF%2B-00-hwmHghEwEGByKOowAogAPbBgUYLZDY9QBJpZYlLUmEnAgEBRUwAa1gyl6sFSQA&v=7.4&f=console) - [8.0](https://php-play.dev/?c=DwfgDgFmBQB2CGBbApgZzPAxsgBAFTQBcBLWAcwG5ppTDkAnAMy1wCU0BXAG0IElY6TFjgDeAX2qYu8VKhwARZIgD20EdByacYDgCMuxTDkYdYmEstg46qQgAoAlAC4c7VNz4CGzbKIkToABIpGTkAXhwAcgAdAltSMmjFFUiqQJRCCGUAExwIyJtCVOpCegBPUWgASED6ZEYuZHNiSwBhaVk8nFhkAHccaPYGpotYdtC7YI7UByotHFrkQg56WAA5JGRsvDKwXAjF4ea26YBaAD4yJYBZJazsyYz7hwurwnZl1Z29xyoNLWIjBwkzqn3Wm22u1wpFs8DMyGUQMG9Uax3BKEhewclXm80WYO%2B%2BwWoJW6K2hNeSw2KF%2B-00-hwmHghEwEGByKOowAogAPbBgUYLZDY9QBJpZYlLUmEnAgEBRUwAa1gyl6sFSQA&v=8.0&f=console) - [8.1](https://php-play.dev/?c=DwfgDgFmBQB2CGBbApgZzPAxsgBAFTQBcBLWAcwG5ppTDkAnAMy1wCU0BXAG0IElY6TFjgDeAX2qYu8VKhwARZIgD20EdByacYDgCMuxTDkYdYmEstg46qQgAoAlAC4c7VNz4CGzbKIkToABIpGTkAXhwAcgAdAltSMmjFFUiqQJRCCGUAExwIyJtCVOpCegBPUWgASED6ZEYuZHNiSwBhaVk8nFhkAHccaPYGpotYdtC7YI7UByotHFrkQg56WAA5JGRsvDKwXAjF4ea26YBaAD4yJYBZJazsyYz7hwurwnZl1Z29xyoNLWIjBwkzqn3Wm22u1wpFs8DMyGUQMG9Uax3BKEhewclXm80WYO%2B%2BwWoJW6K2hNeSw2KF%2B-00-hwmHghEwEGByKOowAogAPbBgUYLZDY9QBJpZYlLUmEnAgEBRUwAa1gyl6sFSQA&v=8.1&f=console) - [8.2](https://php-play.dev/?c=DwfgDgFmBQB2CGBbApgZzPAxsgBAFTQBcBLWAcwG5ppTDkAnAMy1wCU0BXAG0IElY6TFjgDeAX2qYu8VKhwARZIgD20EdByacYDgCMuxTDkYdYmEstg46qQgAoAlAC4c7VNz4CGzbKIkToABIpGTkAXhwAcgAdAltSMmjFFUiqQJRCCGUAExwIyJtCVOpCegBPUWgASED6ZEYuZHNiSwBhaVk8nFhkAHccaPYGpotYdtC7YI7UByotHFrkQg56WAA5JGRsvDKwXAjF4ea26YBaAD4yJYBZJazsyYz7hwurwnZl1Z29xyoNLWIjBwkzqn3Wm22u1wpFs8DMyGUQMG9Uax3BKEhewclXm80WYO%2B%2BwWoJW6K2hNeSw2KF%2B-00-hwmHghEwEGByKOowAogAPbBgUYLZDY9QBJpZYlLUmEnAgEBRUwAa1gyl6sFSQA&v=8.2&f=console) - [8.3](https://php-play.dev/?c=DwfgDgFmBQB2CGBbApgZzPAxsgBAFTQBcBLWAcwG5ppTDkAnAMy1wCU0BXAG0IElY6TFjgDeAX2qYu8VKhwARZIgD20EdByacYDgCMuxTDkYdYmEstg46qQgAoAlAC4c7VNz4CGzbKIkToABIpGTkAXhwAcgAdAltSMmjFFUiqQJRCCGUAExwIyJtCVOpCegBPUWgASED6ZEYuZHNiSwBhaVk8nFhkAHccaPYGpotYdtC7YI7UByotHFrkQg56WAA5JGRsvDKwXAjF4ea26YBaAD4yJYBZJazsyYz7hwurwnZl1Z29xyoNLWIjBwkzqn3Wm22u1wpFs8DMyGUQMG9Uax3BKEhewclXm80WYO%2B%2BwWoJW6K2hNeSw2KF%2B-00-hwmHghEwEGByKOowAogAPbBgUYLZDY9QBJpZYlLUmEnAgEBRUwAa1gyl6sFSQA&v=8.3&f=console)

Given the following, simplified, class:

```php
<?php

declare(strict_types=1);

namespace Some\Namespace;

use Magento\Framework\Api\SearchCriteriaInterface;
use Magento\Framework\Exception\NotFoundException;
use Magento\Framework\Api\SearchResultsInterface;

class Details
{
    /**
     * @param SearchCriteriaInterface $searchCriteria
     *
     * @return SearchResultsInterface
     *
     * @throws NotFoundException
     */
    public function getHistory(SearchCriteriaInterface $searchCriteria): SearchResultsInterface
    {
        (...)
    }
}

```

Current code execution relies in `\Magento\Framework\Reflection\MethodsMap::getMethodReturnType` method, which in turn uses only the `@return` tag, to retrieve the return type. In the case above, `SearchResultsInterface` is found as the `@return` type declared in the doc block, but it fails to return its FQDN, so the `\is_subclass_of` check fails.

Simplifying and importing classes instead of using its FQDN every time is a common practice (PhpStorm, [php-cs-fixer](https://cs.symfony.com/doc/rules/import/fully_qualified_strict_types.html)...), and cannot be applied in a standard way if this `@return` tag needs to be fully qualified in order to work.

This change proposes to use reflection to get method declared return type, which is enforced to return, and is more reliable than a doc block annotation for validation. Approach can be discussed, as the suggested changes have been implemented quickly for testing purposes (although they work) and may be improved regarding caching, performance, or another criteria.

I hope this PR proposal is interesting to be added to source code, write me for any aclaration if needed, thank you!