### PR TITLE
Fix boolean filter behavior

### DIFF
--- a/view/adminhtml/templates/grid/filter/bool.phtml
+++ b/view/adminhtml/templates/grid/filter/bool.phtml
@@ -11,8 +11,10 @@ $value = $filter->getValue();
 ?>
 <select name="<?= $escaper->escapeHtmlAttr($filter->getInputName()) ?>"
         form="<?= $filter->getFormId() ?>"
-        class="form-select w-full">
+        class="form-select w-full"
+        @change="formGridUpdate($event.target.form)"
+>
     <option value=""> </option>
     <option value="1"<?= isset($value) && $value ? ' selected' : '' ?>><?= __('Yes') ?></option>
-    <option value="0"<?= isset($value) && !$value ? ' selected' : '' ?>><?= __('No') ?></option>
+    <option value="0"<?= isset($value) && !$value && $value !== '' ? ' selected' : '' ?>><?= __('No') ?></option>
 </select>


### PR DESCRIPTION
Case:
* Have one boolean filter in a grid
* Have one other filter in the same grid
* Filter the grid using the other filter

IS:
* The boolean filter jumps to "No"
* On the next request, the "No" is applied for this filter

SHOULD: 
* The boolean filter stays empty and doesn't affect the results

This PR fixes this behavior. It also makes sure that a boolean filter is applied after the value is changed.