### PR TITLE
Re-allow template filenames with hyphens

### DIFF
--- a/etc/hyva-grid.xsd
+++ b/etc/hyva-grid.xsd
@@ -176,7 +176,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:normalizedString">
-            <xs:pattern value="[A-Z][a-zA-Z0-9]*_[A-Z][a-zA-Z0-9]*::[a-zA-Z/.-_]+\.phtml"/>
+            <xs:pattern value="[A-Z][a-zA-Z0-9]*_[A-Z][a-zA-Z0-9]*::[a-zA-Z/._-]+\.phtml"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
The template pattern `[a-zA-Z/.-_]` reads `.-_` as a **range**, excluding literal hyphens.
Thus, hyphenated template names (expiration-date.phtml, etc.) fail XSD validation.
By changing the pattern order to `._-` we don't have a range any more, but the intended character choice.
This bug was introduced in 1.1.27.